### PR TITLE
Add build script and Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-
 A3-Antistasi/mission.sqm
+build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+sudo: required
+language: minimal
+services:
+- docker
+install:
+- docker pull anpage/makepbo
+script:
+- docker run --rm -v ${PWD}:/data --entrypoint bash anpage/makepbo build.sh

--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@ do
     cp -r A3-Antistasi/* build/$variant
     rm -rf build/$variant/Templates/*/
 
-    makepbo -PN build/$variant/ build/$variant.pbo
+    makepbo -P -X none build/$variant/ build/$variant.pbo
 
     rm -rf build/$variant/
 done

--- a/build.sh
+++ b/build.sh
@@ -4,29 +4,17 @@
 if [ -d "build" ]; then rm -r build; fi
 mkdir -p build
 
-# Build greenfor Altis
-cp -r A3-Antistasi/Templates/A3-AATemplate.Altis build/A3-AATemplate.Altis
-cp -r A3-Antistasi/* build/A3-AATemplate.Altis
-rm -rf build/A3-AATemplate.Altis/Templates/*/
+# Define variant template folders
+variants=( A3-AATemplate.Altis A3-AA-BLUFORTemplate.Altis A3-WotPTemplate.Tanoa )
 
-makepbo -PN build/A3-AATemplate.Altis/ build/A3-AATemplate.Altis.pbo
+# Build each template
+for variant in "${variants[@]}"
+do
+    cp -r A3-Antistasi/Templates/$variant build/$variant
+    cp -r A3-Antistasi/* build/$variant
+    rm -rf build/$variant/Templates/*/
 
-rm -rf build/A3-AATemplate.Altis/
+    makepbo -PN build/$variant/ build/$variant.pbo
 
-# Build blufor Altis
-cp -r A3-Antistasi/Templates/A3-AA-BLUFORTemplate.Altis build/A3-AA-BLUFORTemplate.Altis
-cp -r A3-Antistasi/* build/A3-AA-BLUFORTemplate.Altis
-rm -rf build/A3-AA-BLUFORTemplate.Altis/Templates/*/
-
-makepbo -PN build/A3-AA-BLUFORTemplate.Altis/ build/A3-AA-BLUFORTemplate.Altis.pbo
-
-rm -rf build/A3-AA-BLUFORTemplate.Altis/
-
-# Build Tanoa
-cp -r A3-Antistasi/Templates/A3-WotPTemplate.Tanoa build/A3-WotPTemplate.Tanoa
-cp -r A3-Antistasi/* build/A3-WotPTemplate.Tanoa
-rm -rf build/A3-WotPTemplate.Tanoa/Templates/*/
-
-makepbo -PN build/A3-WotPTemplate.Tanoa/ build/A3-WotPTemplate.Tanoa.pbo
-
-rm -rf build/A3-WotPTemplate.Tanoa/
+    rm -rf build/$variant/
+done

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,32 @@
+#!/bin/env bash
+
+# Make build folder
+if [ -d "build" ]; then rm -r build; fi
+mkdir -p build
+
+# Build greenfor Altis
+cp -r A3-Antistasi/Templates/A3-AATemplate.Altis build/A3-AATemplate.Altis
+cp -r A3-Antistasi/* build/A3-AATemplate.Altis
+rm -rf build/A3-AATemplate.Altis/Templates/*/
+
+makepbo -PN build/A3-AATemplate.Altis/ build/A3-AATemplate.Altis.pbo
+
+rm -rf build/A3-AATemplate.Altis/
+
+# Build blufor Altis
+cp -r A3-Antistasi/Templates/A3-AA-BLUFORTemplate.Altis build/A3-AA-BLUFORTemplate.Altis
+cp -r A3-Antistasi/* build/A3-AA-BLUFORTemplate.Altis
+rm -rf build/A3-AA-BLUFORTemplate.Altis/Templates/*/
+
+makepbo -PN build/A3-AA-BLUFORTemplate.Altis/ build/A3-AA-BLUFORTemplate.Altis.pbo
+
+rm -rf build/A3-AA-BLUFORTemplate.Altis/
+
+# Build Tanoa
+cp -r A3-Antistasi/Templates/A3-WotPTemplate.Tanoa build/A3-WotPTemplate.Tanoa
+cp -r A3-Antistasi/* build/A3-WotPTemplate.Tanoa
+rm -rf build/A3-WotPTemplate.Tanoa/Templates/*/
+
+makepbo -PN build/A3-WotPTemplate.Tanoa/ build/A3-WotPTemplate.Tanoa.pbo
+
+rm -rf build/A3-WotPTemplate.Tanoa/


### PR DESCRIPTION
Relevant to issue #138, this pull request implements a Bash script to build the three variants of the mission as well as a Travis CI configuration for automated builds. This allows for easy automated release deployment as demonstrated by my [fork with changes for my friends' private server](https://github.com/anpage/A3-Antistasi/releases).

It is currently missing the deployment section of the config because it is highly specific to the github repository. Here is an example snippet for the maintainers to use and [here is the link to the Travis CI docs on the subject](https://docs.travis-ci.com/user/deployment/releases/):

```
deploy:
  provider: releases
  api_key:
    secure: [encrypted API key]
  file_glob: true
  file: build/*
  skip_cleanup: true
  on:
    repo: A3Antistasi/A3-Antistasi
    tags: true
```

This runs automated builds for every commit and uploads the PBOs to GitHub for release every time a commit is tagged. These builds take advantage of my own [dockerized version](https://hub.docker.com/r/anpage/makepbo/) of Mikero's PBO tools, but I highly encourage you to fork it and use your own.

One last thing: `makepbo` has an option to check for errors in an addon before building the PBO, but I have that disabled as this process strips out some required files. I'm going to look into being more specific with its parameters to do error checking while still including everything. This would allow Travis CI to serve its usual purpose: automated testing. If something is broken, it'll be able to report it through GitHub and email.