### PR TITLE
Make recognition chance less linear

### DIFF
--- a/A3-Antistasi/undercover.sqf
+++ b/A3-Antistasi/undercover.sqf
@@ -136,13 +136,17 @@ while {_cambiar == ""} do
 					if !(_estaEnControl) then
 						{
 						_aggro = if (lados getVariable [_base,sideUnknown] == malos) then {prestigeNATO} else {prestigeCSAT};
-						if (random 100 < _aggro) then
-							{
-							_cambiar = "Control";
-							}
-						else
-							{
-							_estaEnControl = true;
+						if (player == theBoss) then {
+							if (random 10000 < (_aggro * _aggro)) then {
+								_cambiar = "Control";
+							} else {
+								_estaEnControl = true;
+							};
+						} else {
+							if (random 100 < _aggro) then {
+								_cambiar = "Control";
+							} else {
+								_estaEnControl = true;
 							};
 						};
 					}


### PR DESCRIPTION
The amount of effort that the enemy makes when trying to track down individual members of the group isn't going to progress at the same rate that it gains aggro. Intelligence agencies are going to focus on tracking the ringleaders first and then their associates.

As such, I've curved the recognition chance of everyone except the current guerilla commander.
```
Aggro Rating	Percentage chance of being recognised
1	0.01%
2	0.04%
3	0.09%
4	0.16%
5	0.25%
6	0.36%
7	0.49%
8	0.64%
9	0.81%
10	1%
11	1.21%
12	1.44%
13	1.69%
14	1.96%
15	2.25%
16	2.56%
17	2.89%
18	3.24%
19	3.61%
20	4%
21	4.41%
22	4.84%
23	5.29%
24	5.76%
25	6.25%
26	6.76%
27	7.29%
28	7.84%
29	8.41%
30	9%
31	9.61%
32	10.24%
33	10.89%
34	11.56%
35	12.25%
36	12.96%
37	13.69%
38	14.44%
39	15.21%
40	16%
41	16.81%
42	17.64%
43	18.49%
44	19.36%
45	20.25%
46	21.16%
47	22.09%
48	23.04%
49	24.01%
50	25%
51	26.01%
52	27.04%
53	28.09%
54	29.16%
55	30.25%
56	31.36%
57	32.49%
58	33.64%
59	34.81%
60	36%
61	37.21%
62	38.44%
63	39.69%
64	40.96%
65	42.25%
66	43.56%
67	44.89%
68	46.24%
69	47.61%
70	49%
71	50.41%
72	51.84%
73	53.29%
74	54.76%
75	56.25%
76	57.76%
77	59.29%
78	60.84%
79	62.41%
80	64%
81	65.61%
82	67.24%
83	68.89%
84	70.56%
85	72.25%
86	73.96%
87	75.69%
88	77.44%
89	79.21%
90	81%
91	82.81%
92	84.64%
93	86.49%
94	88.36%
95	90.25%
96	92.16%
97	94.09%
98	96.04%
99	98.01%
100	100%
```