### PR TITLE
changes to mineSweep to try to avoid death while clearing APERS mines

### DIFF
--- a/A3-Antistasi/AI/mineSweep.sqf
+++ b/A3-Antistasi/AI/mineSweep.sqf
@@ -1,6 +1,6 @@
 if (!isServer and hasInterface) exitWith {};
 
-private ["_coste","_grupo","_unit","_minas","_tam","_roads","_camion","_mina","_cuenta", "_truckPos"];
+private ["_coste","_grupo","_unit","_minas","_tam","_roads","_camion","_mina","_cuenta"];
 
 _coste = (server getVariable (SDKExp select 0)) + ([vehSDKRepair] call A3A_fnc_vehiclePrice);
 
@@ -49,8 +49,7 @@ while {alive _unit} do
 			{
 			moveOut _unit;
 			[_unit] orderGetin false;
-			_truckPos = _camion getPos [3, 180];
-			_minas = [_minas,[],{_truckPos distance _x},"ASCEND"] call BIS_fnc_sortBy;
+			_minas = [_minas,[],{_unit distance _x},"ASCEND"] call BIS_fnc_sortBy;
 			_cuenta = 0;
 			_total = count _minas;
 			hint format ["Mine sweeper found %1 mines, deactivating", _total];
@@ -78,13 +77,7 @@ while {alive _unit} do
 						deleteVehicle _mina;
 						deleteVehicle _wh;
 						};
-					// move back to truck before getting next mine to hopefully not step on other mines
-					diag_log format ["Antistasi Mine sweep: Moving to truck for mine %1", _cuenta + 1];
-					_truckPos = _camion getPos [3, 180];
-					_unit doMove _truckPos;
-					_timeOut = time + 120;
 					_cuenta = _cuenta + 1;
-					waitUntil {sleep 0.5; (_unit distance _truckPos < 4) or (!alive _unit) or (time > _timeOut)};
 					};
 				};
 			if(alive _unit) then

--- a/A3-Antistasi/AI/mineSweep.sqf
+++ b/A3-Antistasi/AI/mineSweep.sqf
@@ -1,6 +1,6 @@
 if (!isServer and hasInterface) exitWith {};
 
-private ["_coste","_grupo","_unit","_minas","_tam","_roads","_camion","_mina","_cuenta"];
+private ["_coste","_grupo","_unit","_minas","_tam","_roads","_camion","_mina","_cuenta", "_truckPos"];
 
 _coste = (server getVariable (SDKExp select 0)) + ([vehSDKRepair] call A3A_fnc_vehiclePrice);
 
@@ -21,6 +21,9 @@ _camion = vehSDKRepair createVehicle _pos;
 [_unit] spawn A3A_fnc_FIAinit;
 _grupo addVehicle _camion;
 [_unit] orderGetIn true;
+// Add Mine Detector to detect invisible APERS
+clearMagazineCargo (unitBackpack _unit);
+_unit addItemToBackpack "MineDetector";
 //_unit setBehaviour "SAFE";
 theBoss hcSetGroup [_grupo];
 
@@ -46,32 +49,53 @@ while {alive _unit} do
 			{
 			moveOut _unit;
 			[_unit] orderGetin false;
-			_minas = [_minas,[],{_unit distance _x},"ASCEND"] call BIS_fnc_sortBy;
+			_truckPos = _camion getPos [3, 180];
+			_minas = [_minas,[],{_truckPos distance _x},"ASCEND"] call BIS_fnc_sortBy;
 			_cuenta = 0;
 			_total = count _minas;
+			hint format ["Mine sweeper found %1 mines, deactivating", _total];
+			diag_log format ["Antistasi Mine sweep: Found %1 mines, deactivating", _total];
 			while {(alive _unit) and (_cuenta < _total)} do
 				{
 				_mina = _minas select _cuenta;
+				[_unit] orderGetin false;
+				diag_log format ["Antistasi Mine sweep: Moving to mine %1", _cuenta + 1];
 				_unit doMove position _mina;
 				_timeOut = time + 120;
 				waitUntil {sleep 0.5; (_unit distance _mina < 8) or (!alive _unit) or (time > _timeOut)};
 				if (alive _unit) then
 					{
+					diag_log format ["Antistasi Mine sweep: Deactivating mine %1 of %2", _cuenta + 1, _total];
 					_unit action ["Deactivate",_unit,_mina];
 					//_unit action ["deactivateMine", _unit];
 					sleep 3;
 					_toDelete = nearestObjects [position _unit, ["WeaponHolderSimulated", "GroundWeaponHolder", "WeaponHolder"], 9];
 					if (count _toDelete > 0) then
 						{
+						diag_log format ["Antistasi Mine sweep: Deleting %1 containers for mine %2", count _toDelete, _cuenta + 1];
 						_wh = _toDelete select 0;
 						if (alive _camion) then {_camion addMagazineCargoGlobal [((magazineCargo _wh) select 0),1]};
 						deleteVehicle _mina;
 						deleteVehicle _wh;
 						};
+					// move back to truck before getting next mine to hopefully not step on other mines
+					diag_log format ["Antistasi Mine sweep: Moving to truck for mine %1", _cuenta + 1];
+					_truckPos = _camion getPos [3, 180];
+					_unit doMove _truckPos;
+					_timeOut = time + 120;
 					_cuenta = _cuenta + 1;
+					waitUntil {sleep 0.5; (_unit distance _truckPos < 4) or (!alive _unit) or (time > _timeOut)};
 					};
 				};
-			[_unit] orderGetIn true;
+			if(alive _unit) then
+				{
+				[_unit] orderGetIn true;
+				diag_log "Antistasi Mine sweep: All mines deactivated";
+				hint "Mine sweeper deactivated all mines";
+				} else {
+				hint "Mine sweeper is dead";
+				diag_log "Antistasi Mine sweep: Mine sweeper is dead";
+				};
 			};
 		};
 	sleep 1;


### PR DESCRIPTION
My mine sweepers kept stepping on mines in dense APERS fields left by the enemy so I tried to make it a little smarter. Note, this is only tested on Armia Krajowa version.

1. Add Mine Detector to unit
2. Go back to truck after each mine
  a. helps avoid stepping on other mines
  b. realism?