### PR TITLE
(IFA) Replaced military looking civilian vehicles with actual civilian trucks

### DIFF
--- a/A3-Antistasi/initVar.sqf
+++ b/A3-Antistasi/initVar.sqf
@@ -208,7 +208,7 @@ arrayCivVeh = if !(hayIFA) then
 	}
 else
 	{
-	["LIB_DAK_OpelBlitz_Open","LIB_GazM1","LIB_GazM1_dirty","LIB_DAK_Kfz1","LIB_DAK_Kfz1_hood"];
+	["LIB_CIV_FFI_CitC4", "LIB_CIV_FFI_CitC4_2", "LIB_CIV_FFI_CitC4_3","LIB_GazM1","LIB_GazM1_dirty"];
 	};
 
 


### PR DESCRIPTION
**Description:**
When I started playing this mission, I got confused why are civilians driving vehicles with military camouflage. Was it intended behaviour? I don't know, but I found some civilian looking trucks in FFI faction and replaced the military ones with them.

Note that I only replaced them for ambient civilians, the "civilian" truck that can be bought is still the same.

Pictured are original and replacement vehicles.
![old](https://user-images.githubusercontent.com/2076742/47512752-1fc02d80-d87d-11e8-949f-b739d998e02a.jpg)
![new](https://user-images.githubusercontent.com/2076742/47512748-1e8f0080-d87d-11e8-8a81-ecf0672ae682.jpg)

