### PR TITLE
JNA RHS loadingscreen freeze temp fix

### DIFF
--- a/A3-Antistasi/JeroenArsenal/JNA/fn_arsenal.sqf
+++ b/A3-Antistasi/JeroenArsenal/JNA/fn_arsenal.sqf
@@ -254,7 +254,7 @@ switch _mode do {
 		['showMessage',[_display,"Jeroen (Not) Limited Arsenal"]] call jn_fnc_arsenal;
 		["HighlightMissingIcons",[_display]] call jn_fnc_arsenal;
 
-		//["jn_fnc_arsenal"] call BIS_fnc_endLoadingScreen;
+		["jn_fnc_arsenal"] call BIS_fnc_endLoadingScreen;
 	};
 
 	///////////////////////////////////////////////////////////////////////////////////////////

--- a/A3-Antistasi/JeroenArsenal/JNA/fn_arsenal_init.sqf
+++ b/A3-Antistasi/JeroenArsenal/JNA/fn_arsenal_init.sqf
@@ -51,6 +51,7 @@ if(hasInterface)then{
 		if("bis_fnc_arsenal" in _ids)then{
 		    private _display =  uiNamespace getVariable ["arsanalDisplay","No display"];
 		    titleText["Non Fatal Error, RHS?", "PLAIN"];
+		    diag_log "JNA: Non Fatal Error, RHS?";
 		    ["bis_fnc_arsenal"] call BIS_fnc_endLoadingScreen;
 		};
 	    };

--- a/A3-Antistasi/JeroenArsenal/JNA/fn_arsenal_init.sqf
+++ b/A3-Antistasi/JeroenArsenal/JNA/fn_arsenal_init.sqf
@@ -35,7 +35,26 @@ if(hasInterface)then{
     _object addaction [
         localize "STR_A3_Arsenal",
         {
-            //["jn_fnc_arsenal"] call bis_fnc_startloadingscreen;
+            //start loading screen
+	    ["jn_fnc_arsenal", "Loading Nutz™ Arsenal"] call bis_fnc_startloadingscreen;
+	    [] spawn {
+	        uisleep 5;
+		private _ids = missionnamespace getvariable ["BIS_fnc_startLoadingScreen_ids",[]];
+		if("jn_fnc_arsenal" in _ids)then{
+		    private _display =  uiNamespace getVariable ["arsanalDisplay","No display"];
+		    titleText["ERROR DURING LOADING ARSENAL", "PLAIN"];
+		    _display closedisplay 2;
+		    ["jn_fnc_arsenal"] call BIS_fnc_endLoadingScreen;
+		};
+
+		//TODO this is a temp fix for rhs because it freezes the loading screen if no primaryWeapon was equiped. This will be fix in rhs 0.4.9
+		if("bis_fnc_arsenal" in _ids)then{
+		    private _display =  uiNamespace getVariable ["arsanalDisplay","No display"];
+		    titleText["Non Fatal Error, RHS?", "PLAIN"];
+		    ["bis_fnc_arsenal"] call BIS_fnc_endLoadingScreen;
+		};
+	    };
+	    
             //save proper ammo because BIS arsenal rearms it, and I will over write it back again
             missionNamespace setVariable ["jna_magazines_init",  [
                 magazinesAmmoCargo (uniformContainer player),

--- a/A3-Antistasi/JeroenArsenal/JNA/fn_vehicleArsenal.sqf
+++ b/A3-Antistasi/JeroenArsenal/JNA/fn_vehicleArsenal.sqf
@@ -139,7 +139,7 @@ switch _mode do {
 		["ColorTabs",[_display]] call jn_fnc_vehicleArsenal;
 
 		['showMessage',[_display,"Vehicle inventory"]] call jn_fnc_arsenal;
-		//["jn_fnc_arsenal"] call BIS_fnc_endLoadingScreen;
+		["jn_fnc_arsenal"] call BIS_fnc_endLoadingScreen;
 	};
 
 	///////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Temp fix for infinite loading screen caused by RHS. Forces loading screen to close if its loading for more then 5 secs.

I also re-enabled my loading screens because having them off can cause problems, and the problem with infinite loading screen has been resolved.

Thanks to Jaj22

link to complain
[https://a3antistasi.enjin.com/forum/page/2/m/38173738/viewthread/32246471-infinite-loading-screen-in-arsenal-after-death](url)

link to bug
[http://feedback.rhsmods.org/view.php?id=4712&nbn=1](url)