### PR TITLE
Allow statics to save in elevated buildings

### DIFF
--- a/A3-Antistasi/statSave/saveLoop.sqf
+++ b/A3-Antistasi/statSave/saveLoop.sqf
@@ -154,7 +154,7 @@ _sitios = marcadores select {lados getVariable [_x,sideUnknown] == buenos};
 _posicion = position _x;
 if ((alive _x) and !(surfaceIsWater _posicion) and !(isNull _x)) then
 	{
-	_arrayEst pushBack [typeOf _x,getPos _x,getDir _x];
+	_arrayEst pushBack [typeOf _x,getPosATL _x,getDir _x];
 	/*
 	_cercano = [_sitios,_posicion] call BIS_fnc_nearestPosition;
 	if (_posicion inArea _cercano) then


### PR DESCRIPTION
Use getPosATL instead of getPos when fetching position of static. This means if static is in an elevated position (such as roof of a building) it'll be correctly saved and reappear in the elevated position upon persistent load.