### PR TITLE
IFA3 Detection Fix

### DIFF
--- a/A3-Antistasi/initVar.sqf
+++ b/A3-Antistasi/initVar.sqf
@@ -130,7 +130,7 @@ hayFFAA = false;
 hayIFA = false;
 myCustomMod = false;
 
-if ("LIB_PTRD" in arifles) then
+if (isClass(configFile/"CfgPatches"/"LIB_Core")) then
 	{
 	hayIFA = true;
 	cascos = [];


### PR DESCRIPTION
Add IFA3 detection fix from kju on the IFA3 team. https://steamcommunity.com/workshop/fildetails/discussion/1500572611/3247562523071825720/

IFA3 made some changes to PTRD that made the mod detection fail -- this fixes the detection.

This fixes the problem with 2035-era vehicles and statics being available for free at the flagpole, and the NATO/CSAT labels for faction aggression.