### PR TITLE
Fixed mortar driver randomly leaving gunner behind

### DIFF
--- a/A3-Antistasi/AI/mortyAI.sqf
+++ b/A3-Antistasi/AI/mortyAI.sqf
@@ -28,9 +28,10 @@ while {(alive _morty0) and (alive _morty1)} do
 	[_morty1] orderGetIn true;
 	[_morty1] allowGetIn true;
 	_nul = [_mortero] call A3A_fnc_AIVEHinit;
-
+	
 	waitUntil {sleep 1; ({!(alive _x)} count units _grupo != 0) or !(unitReady _morty0)};
-
+	_morty0 forceSpeed 0;
+	
 	if (({(alive _x)} count units _grupo == count units _grupo) and !(unitReady _morty0)) then
 		{
 		_morty0 addBackpackGlobal _b0;
@@ -39,4 +40,7 @@ while {(alive _morty0) and (alive _morty1)} do
 		moveOut _morty1;
 		deleteVehicle _mortero;
 		};
+	
+	waitUntil {sleep 1; vehicle _morty1 != _morty1};
+	_morty0 forceSpeed -1; 
 	};


### PR DESCRIPTION
I relocate my mortar teams after every fire mission so that they don't get attacked by QRF or counter-batteried. Sometimes the driver would drive off, leaving the gunner behind and forcing him to walk to the next position or to die to a QRF.

This change fixes that by forcing the driver to a speed of 0 until the gunner is in a vehicle, then resetting the speed.